### PR TITLE
PersonCard: fix profile picture bug on Windows

### DIFF
--- a/src/main/java/socialite/ui/PersonCard.java
+++ b/src/main/java/socialite/ui/PersonCard.java
@@ -27,7 +27,6 @@ import socialite.model.handle.Handle.Platform;
 import socialite.model.person.Date;
 import socialite.model.person.Dates;
 import socialite.model.person.Person;
-import socialite.model.person.ProfilePicture;
 import socialite.model.person.Remark;
 
 /**


### PR DESCRIPTION
On Windows, `ProfilePicture.DEFAULT_PICTURE.value.toString()` returns `images\\default_profile_picture.png`. This seems to cause an issue when using the JAR file (but not when running with `gradle run`):

```
Exception in thread "JavaFX Application Thread" java.lang.NullPointerException: Input stream must not be null
        at javafx.scene.image.Image.validateInputStream(Image.java:1117)
        at javafx.scene.image.Image.<init>(Image.java:701)
        at socialite.ui.PersonCard.<init>(PersonCard.java:126)
        at socialite.ui.PersonListPanel$PersonListViewCell.updateItem(PersonListPanel.java:44)
        at socialite.ui.PersonListPanel$PersonListViewCell.updateItem(PersonListPanel.java:35)
        at javafx.scene.control.ListCell.updateItem(ListCell.java:478)
        at javafx.scene.control.ListCell.indexChanged(ListCell.java:337)
        at javafx.scene.control.IndexedCell.updateIndex(IndexedCell.java:120)
        at javafx.scene.control.skin.VirtualFlow.setCellIndex(VirtualFlow.java:1708)
        at javafx.scene.control.skin.VirtualFlow.getCell(VirtualFlow.java:1692)
        at javafx.scene.control.skin.VirtualFlow.getCellLength(VirtualFlow.java:1801)
        at javafx.scene.control.skin.VirtualFlow.computeViewportOffset(VirtualFlow.java:2639)
        at javafx.scene.control.skin.VirtualFlow.layoutChildren(VirtualFlow.java:1245)
        at javafx.scene.Parent.layout(Parent.java:1204)
        at javafx.scene.Parent.layout(Parent.java:1211)
        at javafx.scene.Parent.layout(Parent.java:1211)
        at javafx.scene.Parent.layout(Parent.java:1211)
        at javafx.scene.Parent.layout(Parent.java:1211)
        at javafx.scene.Parent.layout(Parent.java:1211)
        at javafx.scene.Scene.doLayoutPass(Scene.java:576)
        at javafx.scene.Scene$ScenePulseListener.pulse(Scene.java:2482)
        at com.sun.javafx.tk.Toolkit.lambda$runPulse$2(Toolkit.java:412)
        at com.sun.javafx.tk.Toolkit$$Lambda$374/0x0000000000000000.run(Unknown Source)
        at java.base/java.security.AccessController.doPrivileged(AccessController.java:708)
        at com.sun.javafx.tk.Toolkit.runPulse(Toolkit.java:411)
        at com.sun.javafx.tk.Toolkit.firePulse(Toolkit.java:438)
        at com.sun.javafx.tk.quantum.QuantumToolkit.pulse(QuantumToolkit.java:519)
        at com.sun.javafx.tk.quantum.QuantumToolkit.pulse(QuantumToolkit.java:499)
        at com.sun.javafx.tk.quantum.QuantumToolkit.pulseFromQueue(QuantumToolkit.java:492)
        at com.sun.javafx.tk.quantum.QuantumToolkit.lambda$runToolkit$11(QuantumToolkit.java:320)
        at com.sun.javafx.tk.quantum.QuantumToolkit$$Lambda$61/0x0000000000000000.run(Unknown Source)
        at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:96)
        at com.sun.glass.ui.win.WinApplication._runLoop(Native Method)
        at com.sun.glass.ui.win.WinApplication.lambda$runLoop$3(WinApplication.java:174)
        at com.sun.glass.ui.win.WinApplication$$Lambda$57/0x0000000000000000.run(Unknown Source)
        at java.base/java.lang.Thread.run(Thread.java:836)
```

For now, the fix here is to hardcode the exact path to the resource.