### PR TITLE
Add missing commands to `help` feature

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -376,7 +376,7 @@ Format: `help`
 Displays concise instructions for users to learn the given `COMMAND`'s function.
 
 Format: `help COMMAND`
-* Acceptable keywords to use in `COMMAND`: `add` `delete` `edit` `find` `remark`
+* Acceptable keywords to use in `COMMAND`: `add` `delete` `edit` `find` `remark` `share` `picture` `pin` `unpin`
 
 Examples:
 * `help add` displays a concise guide on how to use the `add` command.


### PR DESCRIPTION
Add `share` `picture` `pin` and `unpin` to the list of supported commands under the `help` feature.
Closes #86 and #101 