### PR TITLE
Modify definition of duplicate persons

### DIFF
--- a/src/main/java/socialite/logic/commands/AddCommand.java
+++ b/src/main/java/socialite/logic/commands/AddCommand.java
@@ -47,7 +47,8 @@ public class AddCommand extends Command {
             + PREFIX_DATE + "ord:2020-01-01";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
+    public static final String MESSAGE_DUPLICATE_PERSON =
+            "A contact with the same phone number already exists in the address book!";
     public static final String MESSAGE_HELP_GUIDE = "Enter 'help add' for in-app guidance.";
 
     private final Person toAdd;

--- a/src/main/java/socialite/logic/commands/EditCommand.java
+++ b/src/main/java/socialite/logic/commands/EditCommand.java
@@ -62,7 +62,8 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
+    public static final String MESSAGE_DUPLICATE_PERSON =
+            "A contact with the same phone number already exists in the address book!";
     public static final String MESSAGE_HELP_GUIDE = "Enter 'help edit' for in-app guidance.";
 
     private final Index index;

--- a/src/main/java/socialite/model/person/Person.java
+++ b/src/main/java/socialite/model/person/Person.java
@@ -126,7 +126,6 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName())
                 && otherPerson.getPhone().equals(getPhone());
     }
 

--- a/src/main/java/socialite/model/person/exceptions/DuplicatePersonException.java
+++ b/src/main/java/socialite/model/person/exceptions/DuplicatePersonException.java
@@ -3,7 +3,7 @@ package socialite.model.person.exceptions;
 /**
  * Signals that the operation will result in duplicate Persons
  * (Persons are considered duplicates if they have the same
- * name and phone number).
+ * phone number).
  */
 public class DuplicatePersonException extends RuntimeException {
     public DuplicatePersonException() {

--- a/src/test/java/socialite/model/person/PersonTest.java
+++ b/src/test/java/socialite/model/person/PersonTest.java
@@ -33,33 +33,33 @@ public class PersonTest {
                 .withTags(VALID_TAG_HUSBAND).build();
         Assertions.assertFalse(TypicalPersons.ALICE.isSamePerson(editedAlice));
 
-        // same phone number, all other attributes different -> returns false
+        // same phone number, all other attributes different -> returns true
         editedAlice = new PersonBuilder(TypicalPersons.ALICE)
                 .withName(VALID_NAME_BOB)
                 .withTags(VALID_TAG_HUSBAND).build();
-        Assertions.assertFalse(TypicalPersons.ALICE.isSamePerson(editedAlice));
+        Assertions.assertTrue(TypicalPersons.ALICE.isSamePerson(editedAlice));
 
         // same name and phone number, all other attributes different -> returns true
         editedAlice = new PersonBuilder(TypicalPersons.ALICE)
                 .withTags(VALID_TAG_HUSBAND).build();
         Assertions.assertTrue(TypicalPersons.ALICE.isSamePerson(editedAlice));
 
-        // different name, all other attributes same -> returns false
+        // different name, all other attributes same -> returns true
         editedAlice = new PersonBuilder(TypicalPersons.ALICE).withName(VALID_NAME_BOB).build();
-        Assertions.assertFalse(TypicalPersons.ALICE.isSamePerson(editedAlice));
+        Assertions.assertTrue(TypicalPersons.ALICE.isSamePerson(editedAlice));
 
         // different phone number, all other attributes same -> returns false
         editedAlice = new PersonBuilder(TypicalPersons.ALICE).withPhone(VALID_PHONE_BOB).build();
         Assertions.assertFalse(TypicalPersons.ALICE.isSamePerson(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Person editedBob = new PersonBuilder(TypicalPersons.BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        Assertions.assertFalse(TypicalPersons.BOB.isSamePerson(editedBob));
+        Assertions.assertTrue(TypicalPersons.BOB.isSamePerson(editedBob));
 
-        // name has trailing spaces, all other attributes same -> returns false
+        // name has trailing spaces, all other attributes same -> returns true
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(TypicalPersons.BOB).withName(nameWithTrailingSpaces).build();
-        Assertions.assertFalse(TypicalPersons.BOB.isSamePerson(editedBob));
+        Assertions.assertTrue(TypicalPersons.BOB.isSamePerson(editedBob));
     }
 
     @Test

--- a/src/test/java/socialite/model/person/UniquePersonListTest.java
+++ b/src/test/java/socialite/model/person/UniquePersonListTest.java
@@ -59,13 +59,13 @@ public class UniquePersonListTest {
     }
 
     @Test
-    public void contains_personWithSamePhoneNumberInList_returnsFalse() {
+    public void contains_personWithSamePhoneNumberInList_returnsTrue() {
         uniquePersonList.add(TypicalPersons.ALICE);
         Person editedAlice = new PersonBuilder(TypicalPersons.ALICE)
                 .withName(VALID_NAME_BOB)
                 .withTags(VALID_TAG_HUSBAND)
                 .build();
-        assertFalse(uniquePersonList.contains(editedAlice));
+        assertTrue(uniquePersonList.contains(editedAlice));
     }
 
     @Test
@@ -77,6 +77,29 @@ public class UniquePersonListTest {
     public void add_duplicatePerson_throwsDuplicatePersonException() {
         uniquePersonList.add(TypicalPersons.ALICE);
         Assert.assertThrows(DuplicatePersonException.class, () -> uniquePersonList.add(TypicalPersons.ALICE));
+    }
+
+    @Test
+    public void add_personWithSamePhone_throwsDuplicatePersonException() {
+        uniquePersonList.add(TypicalPersons.ALICE);
+        Person bobWithAlicePhone = new PersonBuilder(TypicalPersons.BOB)
+                .withPhone(TypicalPersons.ALICE.getPhone().value)
+                .build();
+        Assert.assertThrows(DuplicatePersonException.class, ()
+            -> uniquePersonList.add(bobWithAlicePhone));
+    }
+
+    @Test
+    public void add_personWithSameName_success() {
+        uniquePersonList.add(TypicalPersons.ALICE);
+        Person bobWithAliceName = new PersonBuilder(TypicalPersons.BOB)
+                .withName(TypicalPersons.ALICE.getName().toString())
+                .build();
+        uniquePersonList.add(bobWithAliceName);
+        UniquePersonList expectedUniquePersonList = new UniquePersonList();
+        expectedUniquePersonList.add(TypicalPersons.ALICE);
+        expectedUniquePersonList.add(bobWithAliceName);
+        assertEquals(uniquePersonList, expectedUniquePersonList);
     }
 
     @Test
@@ -129,6 +152,17 @@ public class UniquePersonListTest {
     }
 
     @Test
+    public void setPerson_editedPersonHasSamePhone_success() {
+        uniquePersonList.add(TypicalPersons.ALICE);
+        Person bobWithAlicePhone = new PersonBuilder(TypicalPersons.BOB)
+                .withPhone(TypicalPersons.ALICE.getPhone().toString()).build();
+        uniquePersonList.setPerson(TypicalPersons.ALICE, bobWithAlicePhone);
+        UniquePersonList expectedUniquePersonList = new UniquePersonList();
+        expectedUniquePersonList.add(bobWithAlicePhone);
+        assertEquals(expectedUniquePersonList, uniquePersonList);
+    }
+
+    @Test
     public void setPerson_editedPersonHasNonUniqueIdentity_throwsDuplicatePersonException() {
         uniquePersonList.add(TypicalPersons.ALICE);
         uniquePersonList.add(TypicalPersons.BOB);
@@ -141,17 +175,6 @@ public class UniquePersonListTest {
         uniquePersonList.add(TypicalPersons.ALICE);
         Person differentAlice = new PersonBuilder(TypicalPersons.ALICE)
                 .withPhone(VALID_PHONE_BOB)
-                .build();
-        uniquePersonList.add(differentAlice);
-        Assert.assertThrows(DuplicatePersonException.class, ()
-            -> uniquePersonList.setPerson(TypicalPersons.ALICE, differentAlice));
-    }
-
-    @Test
-    public void setPerson_editedPersonHasSamePhone_throwsDuplicatePersonException() {
-        uniquePersonList.add(TypicalPersons.ALICE);
-        Person differentAlice = new PersonBuilder(TypicalPersons.ALICE)
-                .withName(VALID_NAME_BOB)
                 .build();
         uniquePersonList.add(differentAlice);
         Assert.assertThrows(DuplicatePersonException.class, ()

--- a/src/test/java/socialite/model/person/UniquePersonListTest.java
+++ b/src/test/java/socialite/model/person/UniquePersonListTest.java
@@ -122,7 +122,7 @@ public class UniquePersonListTest {
     }
 
     @Test
-    public void setPerson_editedPersonIsSamePerson_success() {
+    public void setPerson_editedPersonNotInListIsSamePerson_success() {
         uniquePersonList.add(TypicalPersons.ALICE);
         uniquePersonList.setPerson(TypicalPersons.ALICE, TypicalPersons.ALICE);
         UniquePersonList expectedUniquePersonList = new UniquePersonList();
@@ -131,7 +131,7 @@ public class UniquePersonListTest {
     }
 
     @Test
-    public void setPerson_editedPersonHasSameIdentity_success() {
+    public void setPerson_editedPersonNotInListHasSameIdentity_success() {
         uniquePersonList.add(TypicalPersons.ALICE);
         Person editedAlice = new PersonBuilder(TypicalPersons.ALICE)
                 .withTags(VALID_TAG_HUSBAND)
@@ -143,7 +143,7 @@ public class UniquePersonListTest {
     }
 
     @Test
-    public void setPerson_editedPersonHasDifferentIdentity_success() {
+    public void setPerson_editedPersonNotInListHasDifferentIdentity_success() {
         uniquePersonList.add(TypicalPersons.ALICE);
         uniquePersonList.setPerson(TypicalPersons.ALICE, TypicalPersons.BOB);
         UniquePersonList expectedUniquePersonList = new UniquePersonList();
@@ -152,7 +152,7 @@ public class UniquePersonListTest {
     }
 
     @Test
-    public void setPerson_editedPersonHasSamePhone_success() {
+    public void setPerson_editedPersonNotInListHasSamePhone_success() {
         uniquePersonList.add(TypicalPersons.ALICE);
         Person bobWithAlicePhone = new PersonBuilder(TypicalPersons.BOB)
                 .withPhone(TypicalPersons.ALICE.getPhone().toString()).build();
@@ -163,7 +163,7 @@ public class UniquePersonListTest {
     }
 
     @Test
-    public void setPerson_editedPersonHasNonUniqueIdentity_throwsDuplicatePersonException() {
+    public void setPerson_editedPersonExistsInList_throwsDuplicatePersonException() {
         uniquePersonList.add(TypicalPersons.ALICE);
         uniquePersonList.add(TypicalPersons.BOB);
         Assert.assertThrows(DuplicatePersonException.class, ()
@@ -171,7 +171,7 @@ public class UniquePersonListTest {
     }
 
     @Test
-    public void setPerson_editedPersonHasSameName_throwsDuplicatePersonException() {
+    public void setPerson_editedPersonExistsInListWithDiffPhone_throwsDuplicatePersonException() {
         uniquePersonList.add(TypicalPersons.ALICE);
         Person differentAlice = new PersonBuilder(TypicalPersons.ALICE)
                 .withPhone(VALID_PHONE_BOB)
@@ -179,6 +179,20 @@ public class UniquePersonListTest {
         uniquePersonList.add(differentAlice);
         Assert.assertThrows(DuplicatePersonException.class, ()
             -> uniquePersonList.setPerson(TypicalPersons.ALICE, differentAlice));
+    }
+
+    @Test
+    // Amy and differentAmy (who has Bob's phone number) already exist in the list.
+    // Attempting to set Amy with Bob's attributes will throw a DuplicatePersonException as differentAmy
+    // has Bob's phone number as her attribute.
+    public void setPerson_editedPersonHasSamePhoneNumber_throwsDuplicatePersonException() {
+        uniquePersonList.add(TypicalPersons.AMY);
+        Person differentAmy = new PersonBuilder(TypicalPersons.AMY)
+                .withPhone(VALID_PHONE_BOB)
+                .build();
+        uniquePersonList.add(differentAmy);
+        Assert.assertThrows(DuplicatePersonException.class, ()
+            -> uniquePersonList.setPerson(TypicalPersons.AMY, TypicalPersons.BOB));
     }
 
     @Test


### PR DESCRIPTION
As advised by peer reviewer from #113, the criteria for duplicate persons has now been altered such that comparisons are solely performed on the phone number of contacts. As a result, contacts with similar names (regardless of case) can be added to SociaLite as long as they do not share the same phone number. A DuplicatePersonException will only be thrown when a contact with the same phone number already exists in SociaLite.

Tests and error messages have been updated for greater accuracy and precision in this PR as well.

Negative Test Case Example - Cannot add "Jill" as the phone number already exists:
![image](https://user-images.githubusercontent.com/55949074/139612188-90253415-a33b-49d6-bb86-d421997d9f79.png)

Positive Test Case Example - Can add "jack" as he has a different phone number from "Jack":
![image](https://user-images.githubusercontent.com/55949074/139612218-4c5522f0-d63f-4848-9c61-930cfc137b6c.png)


Fixes #113 and #117.