### PR TITLE
Fix invalid index for picture command

### DIFF
--- a/src/main/java/socialite/logic/commands/PictureCommand.java
+++ b/src/main/java/socialite/logic/commands/PictureCommand.java
@@ -27,15 +27,29 @@ public class PictureCommand extends Command {
     public static final String MESSAGE_HELP_GUIDE =
             "Enter picture INDEX to add a profile picture to the person at INDEX";
     private final Index index;
+    private final boolean useGui;
+    private File picture;
 
     /**
      * Creates a command that adds a picture to a person
      * @param index Index of person to add picture to
      */
-    public PictureCommand(Index index) {
+    public PictureCommand(Index index, boolean useGui) {
         requireNonNull(index);
 
         this.index = index;
+        this.useGui = useGui;
+    }
+
+    /**
+     * Constructor with a provided picture used for testing
+     */
+    public PictureCommand(Index index, boolean useGui, File picture) {
+        requireNonNull(index);
+
+        this.index = index;
+        this.useGui = useGui;
+        this.picture = picture;
     }
 
     @Override
@@ -48,7 +62,9 @@ public class PictureCommand extends Command {
         }
 
         Person personToAddPic = lastShownList.get(index.getZeroBased());
-        File picture = getPic();
+        if (useGui) {
+            picture = getPic();
+        }
         if (picture == null) {
             return new CommandResult("Command aborted");
         }

--- a/src/main/java/socialite/logic/commands/PictureCommand.java
+++ b/src/main/java/socialite/logic/commands/PictureCommand.java
@@ -14,6 +14,7 @@ import socialite.logic.commands.exceptions.CommandException;
 import socialite.model.Model;
 import socialite.model.person.Person;
 import socialite.model.person.ProfilePicture;
+import socialite.ui.MainWindow;
 
 public class PictureCommand extends Command {
 
@@ -26,25 +27,19 @@ public class PictureCommand extends Command {
     public static final String MESSAGE_HELP_GUIDE =
             "Enter picture INDEX to add a profile picture to the person at INDEX";
     private final Index index;
-    private final File picture;
 
     /**
      * Creates a command that adds a picture to a person
      * @param index Index of person to add picture to
-     * @param picture File to add to person
      */
-    public PictureCommand(Index index, File picture) {
+    public PictureCommand(Index index) {
         requireNonNull(index);
 
         this.index = index;
-        this.picture = picture;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        if (this.picture == null) {
-            return new CommandResult("Command aborted");
-        }
         requireNonNull(model);
         List<Person> lastShownList = model.getFilteredPersonList();
 
@@ -53,11 +48,22 @@ public class PictureCommand extends Command {
         }
 
         Person personToAddPic = lastShownList.get(index.getZeroBased());
+        File picture = getPic();
+        if (picture == null) {
+            return new CommandResult("Command aborted");
+        }
+
         Person personWithPic = addPicToPerson(personToAddPic, picture, model);
 
         model.setPerson(personToAddPic, personWithPic);
         model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult("picture added", false, false, true);
+    }
+
+    private File getPic() {
+        MainWindow window = MainWindow.getWindow();
+        File file = window.getFile();
+        return file;
     }
 
     private Person addPicToPerson(Person person, File file, Model model) {

--- a/src/main/java/socialite/logic/parser/PictureCommandParser.java
+++ b/src/main/java/socialite/logic/parser/PictureCommandParser.java
@@ -2,13 +2,10 @@ package socialite.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
-import java.io.File;
-
 import socialite.commons.core.Messages;
 import socialite.commons.core.index.Index;
 import socialite.logic.commands.PictureCommand;
 import socialite.logic.parser.exceptions.ParseException;
-import socialite.ui.MainWindow;
 
 public class PictureCommandParser implements Parser<PictureCommand> {
 
@@ -25,8 +22,6 @@ public class PictureCommandParser implements Parser<PictureCommand> {
                     String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, PictureCommand.MESSAGE_HELP_GUIDE), pe);
         }
 
-        MainWindow window = MainWindow.getWindow();
-        File file = window.getFile();
-        return new PictureCommand(index, file);
+        return new PictureCommand(index);
     }
 }

--- a/src/main/java/socialite/logic/parser/PictureCommandParser.java
+++ b/src/main/java/socialite/logic/parser/PictureCommandParser.java
@@ -22,6 +22,6 @@ public class PictureCommandParser implements Parser<PictureCommand> {
                     String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, PictureCommand.MESSAGE_HELP_GUIDE), pe);
         }
 
-        return new PictureCommand(index);
+        return new PictureCommand(index, true);
     }
 }


### PR DESCRIPTION
Previously:
Error about invalid index only showed after the filechooser was shown and file was chosen

Now: 
Error should show immediately, before file chooser is shown.

Closes #112 