### PR TITLE
Fix issue where handles require two clicks

### DIFF
--- a/src/main/java/socialite/ui/PersonCard.java
+++ b/src/main/java/socialite/ui/PersonCard.java
@@ -234,7 +234,7 @@ public class PersonCard extends UiPart<Region> {
             label.setText("@" + handle + " ");
             label.setOnMouseEntered(Event -> label.setUnderline(true));
             label.setOnMouseExited(Event -> label.setUnderline(false));
-            label.setOnMouseClicked(Event -> this.openBrowser(handle.getUrl()));
+            label.setOnMousePressed(Event -> this.openBrowser(handle.getUrl()));
         } else {
             box.setVisible(false);
         }


### PR DESCRIPTION
Previously, handles required two clicks to open the url in the browser. Changed the event listener to listen to mouse pressed event instead of mouse clicked event. Seem to solve the problem 

Closes #98 