### PR TITLE
RemarkCommand: fix bug when editing a person

### DIFF
--- a/src/main/java/socialite/logic/commands/RemarkCommand.java
+++ b/src/main/java/socialite/logic/commands/RemarkCommand.java
@@ -61,6 +61,8 @@ public class RemarkCommand extends Command {
                 personToEdit.getTags(), personToEdit.getFacebook(), personToEdit.getInstagram(),
                 personToEdit.getTelegram(), personToEdit.getTiktok(), personToEdit.getTwitter(),
                 personToEdit.getDates());
+        editedPerson.setProfilePicture(personToEdit.getProfilePicture().value);
+        editedPerson.setPinned(personToEdit.getPinnedStatus());
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/socialite/model/person/Person.java
+++ b/src/main/java/socialite/model/person/Person.java
@@ -184,7 +184,8 @@ public class Person {
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, remark, tags, facebook, instagram, telegram, tiktok, twitter, dates);
+        return Objects.hash(name, phone, remark, tags, facebook, instagram, telegram, tiktok, twitter, dates,
+                profilePicture, isPinned);
     }
 
     /**
@@ -274,6 +275,7 @@ public class Person {
                 this.name, this.phone, this.remark, this.tags, this.facebook, this.instagram, this.telegram,
                 this.tiktok, this.twitter, this.dates);
         copy.setProfilePicture(this.profilePicture.value);
+        copy.setPinned(this.isPinned);
         return copy;
     }
 }

--- a/src/test/java/socialite/logic/commands/RemarkCommandTest.java
+++ b/src/test/java/socialite/logic/commands/RemarkCommandTest.java
@@ -52,6 +52,28 @@ public class RemarkCommandTest {
     }
 
     @Test
+    public void execute_addRemarkPinnedPersonUnfilteredList_success() {
+        // Duplicate model to test pinning the first person.
+        Model model = new ModelManager(
+                getTypicalContactList(), new UserPrefs(), new CommandHistory());
+
+        Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        firstPerson.setPinned(true);
+        Person editedPerson = new PersonBuilder(firstPerson).withRemark(REMARK_STUB).build();
+
+        RemarkCommand remarkCommand = new RemarkCommand(INDEX_FIRST_PERSON, new Remark(editedPerson.getRemark().get()));
+
+        String expectedMessage = String.format(RemarkCommand.MESSAGE_ADD_REMARK_SUCCESS, editedPerson);
+
+        Model expectedModel =
+                new ModelManager(
+                        new ContactList(model.getContactList()), new UserPrefs(), new CommandHistory());
+        expectedModel.setPerson(firstPerson, editedPerson);
+
+        assertCommandSuccess(remarkCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
     public void execute_deleteRemarkUnfilteredList_success() {
         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Person editedPerson = new PersonBuilder(firstPerson).withRemark(null).build();

--- a/src/test/java/socialite/testutil/PersonBuilder.java
+++ b/src/test/java/socialite/testutil/PersonBuilder.java
@@ -43,7 +43,7 @@ public class PersonBuilder {
     private Twitter twitter;
     private Dates dates;
     private ProfilePicture profilePic;
-    private boolean pinned;
+    private boolean isPinned;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -60,7 +60,7 @@ public class PersonBuilder {
         twitter = new Twitter(DEFAULT_TWITTER);
         dates = new Dates();
         profilePic = DEFAULT_PROFILE_PIC;
-        pinned = false;
+        isPinned = false;
     }
 
     /**
@@ -78,7 +78,7 @@ public class PersonBuilder {
         twitter = personToCopy.getTwitter();
         dates = personToCopy.getDates();
         profilePic = personToCopy.getProfilePicture();
-        pinned = personToCopy.getPinnedStatus();
+        isPinned = personToCopy.getPinnedStatus();
     }
 
     /**
@@ -172,8 +172,8 @@ public class PersonBuilder {
     /**
      * Sets the pinned status of the (@code Person} that we are building
      */
-    public PersonBuilder withPinnedStatus(boolean pinned) {
-        this.pinned = pinned;
+    public PersonBuilder withPinnedStatus(boolean isPinned) {
+        this.isPinned = isPinned;
         return this;
     }
 
@@ -184,7 +184,7 @@ public class PersonBuilder {
     public Person build() {
         Person p = new Person(name, phone, remark, tags, facebook, instagram, telegram, tiktok, twitter, dates);
         p.setProfilePicture(profilePic.value);
-        p.setPinned(pinned);
+        p.setPinned(isPinned);
         return p;
     }
 

--- a/src/test/java/socialite/testutil/PersonBuilder.java
+++ b/src/test/java/socialite/testutil/PersonBuilder.java
@@ -43,6 +43,7 @@ public class PersonBuilder {
     private Twitter twitter;
     private Dates dates;
     private ProfilePicture profilePic;
+    private boolean pinned;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -59,6 +60,7 @@ public class PersonBuilder {
         twitter = new Twitter(DEFAULT_TWITTER);
         dates = new Dates();
         profilePic = DEFAULT_PROFILE_PIC;
+        pinned = false;
     }
 
     /**
@@ -76,6 +78,7 @@ public class PersonBuilder {
         twitter = personToCopy.getTwitter();
         dates = personToCopy.getDates();
         profilePic = personToCopy.getProfilePicture();
+        pinned = personToCopy.getPinnedStatus();
     }
 
     /**
@@ -159,10 +162,18 @@ public class PersonBuilder {
     }
 
     /**
-     * Sets the {@code Profile Picture} of the (@code Person} that we are building
+     * Sets the {@code ProfilePicture} of the (@code Person} that we are building
      */
     public PersonBuilder withProfilePic(ProfilePicture pic) {
         this.profilePic = pic;
+        return this;
+    }
+
+    /**
+     * Sets the pinned status of the (@code Person} that we are building
+     */
+    public PersonBuilder withPinnedStatus(boolean pinned) {
+        this.pinned = pinned;
         return this;
     }
 
@@ -173,6 +184,7 @@ public class PersonBuilder {
     public Person build() {
         Person p = new Person(name, phone, remark, tags, facebook, instagram, telegram, tiktok, twitter, dates);
         p.setProfilePicture(profilePic.value);
+        p.setPinned(pinned);
         return p;
     }
 

--- a/src/test/java/socialite/testutil/TypicalPersons.java
+++ b/src/test/java/socialite/testutil/TypicalPersons.java
@@ -36,7 +36,8 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withPhone("94351253").withRemark("She likes aardvarks.").withTags("friends")
             .withFacebook("alice.p").withInstagram("alice.p").withTelegram("alice_pauline")
-            .withTikTok("alice.pauline").withTwitter(null).withProfilePic(PersonBuilder.DEFAULT_PROFILE_PIC).build();
+            .withTikTok("alice.pauline").withTwitter(null).withProfilePic(PersonBuilder.DEFAULT_PROFILE_PIC)
+            .withPinnedStatus(true).build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withPhone("98765432").withRemark("He can't take beer!").withTags("owesMoney", "friends")
             .withFacebook("benson.m").withInstagram("benson.m").withTelegram("benson_meier")

--- a/src/test/java/socialite/testutil/TypicalPersons.java
+++ b/src/test/java/socialite/testutil/TypicalPersons.java
@@ -36,8 +36,7 @@ public class TypicalPersons {
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withPhone("94351253").withRemark("She likes aardvarks.").withTags("friends")
             .withFacebook("alice.p").withInstagram("alice.p").withTelegram("alice_pauline")
-            .withTikTok("alice.pauline").withTwitter(null).withProfilePic(PersonBuilder.DEFAULT_PROFILE_PIC)
-            .withPinnedStatus(true).build();
+            .withTikTok("alice.pauline").withTwitter(null).withProfilePic(PersonBuilder.DEFAULT_PROFILE_PIC).build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
             .withPhone("98765432").withRemark("He can't take beer!").withTags("owesMoney", "friends")
             .withFacebook("benson.m").withInstagram("benson.m").withTelegram("benson_meier")


### PR DESCRIPTION
The person's pinned status and profile picture were not copied when editing the person's remark using the `RemarkCommand`.

This PR also updates the test, to ensure that at least one person with a pinned status is edited by the `RemarkCommandTest`.

Closes #175.