### PR TITLE
PersonCard: make use of `CommandExecutor` to execute commands

### DIFF
--- a/src/main/java/socialite/ui/CommandBox.java
+++ b/src/main/java/socialite/ui/CommandBox.java
@@ -8,8 +8,6 @@ import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
-import socialite.logic.Logic;
-import socialite.logic.commands.CommandResult;
 import socialite.logic.commands.exceptions.CommandException;
 import socialite.logic.parser.exceptions.ParseException;
 import socialite.model.ReadOnlyCommandHistory;
@@ -115,18 +113,4 @@ public class CommandBox extends UiPart<Region> {
 
         styleClass.add(ERROR_STYLE_CLASS);
     }
-
-    /**
-     * Represents a function that can execute commands.
-     */
-    @FunctionalInterface
-    public interface CommandExecutor {
-        /**
-         * Executes the command and returns the result.
-         *
-         * @see Logic#execute(String)
-         */
-        CommandResult execute(String commandText) throws CommandException, ParseException;
-    }
-
 }

--- a/src/main/java/socialite/ui/CommandExecutor.java
+++ b/src/main/java/socialite/ui/CommandExecutor.java
@@ -1,0 +1,19 @@
+package socialite.ui;
+
+import socialite.logic.Logic;
+import socialite.logic.commands.CommandResult;
+import socialite.logic.commands.exceptions.CommandException;
+import socialite.logic.parser.exceptions.ParseException;
+
+/**
+ * Represents a function that can execute commands.
+ */
+@FunctionalInterface
+public interface CommandExecutor {
+    /**
+     * Executes the command and returns the result.
+     *
+     * @see Logic#execute(String)
+     */
+    CommandResult execute(String commandText) throws CommandException, ParseException;
+}

--- a/src/main/java/socialite/ui/MainWindow.java
+++ b/src/main/java/socialite/ui/MainWindow.java
@@ -127,7 +127,7 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        personListPanel = new PersonListPanel(this::executeCommand, logic.getFilteredPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
@@ -225,7 +225,7 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     void showFullPersonList() {
-        personListPanel = new PersonListPanel(logic.getFullPersonList());
+        personListPanel = new PersonListPanel(this::executeCommand, logic.getFullPersonList());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
     }
 

--- a/src/main/java/socialite/ui/PersonCard.java
+++ b/src/main/java/socialite/ui/PersonCard.java
@@ -15,15 +15,12 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.input.Clipboard;
-import javafx.scene.input.ClipboardContent;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.shape.Circle;
-import socialite.logic.commands.PinCommand;
-import socialite.logic.commands.ShareCommand;
-import socialite.logic.commands.UnpinCommand;
+import socialite.logic.commands.exceptions.CommandException;
+import socialite.logic.parser.exceptions.ParseException;
 import socialite.model.handle.Handle;
 import socialite.model.handle.Handle.Platform;
 import socialite.model.person.Date;
@@ -301,28 +298,18 @@ public class PersonCard extends UiPart<Region> {
     }
 
     @FXML
-    private void handlePinButtonAction() {
+    private void handlePinButtonAction() throws CommandException, ParseException {
         MainWindow mainWindow = MainWindow.getWindow();
         if (person.isPinned()) {
-            person.unpin();
-            mainWindow.setFeedbackToUser(String.format(UnpinCommand.MESSAGE_UNPIN_PERSON_SUCCESS, person));
+            commandExecutor.execute("unpin " + displayedIndex);
         } else {
-            person.pin();
-            mainWindow.setFeedbackToUser(String.format(PinCommand.MESSAGE_PIN_PERSON_SUCCESS, person));
+            commandExecutor.execute("pin " + displayedIndex);
         }
-        mainWindow.showFullPersonList();
     }
 
     @FXML
-    private void handleShareButtonAction() {
-        Clipboard clipboard = Clipboard.getSystemClipboard();
-        ClipboardContent content = new ClipboardContent();
-        String shareInfo = person.toSharingString();
-        content.putString(shareInfo);
-        clipboard.setContent(content);
-
-        // Show the copied info in result display
-        MainWindow.getWindow().setFeedbackToUser(String.format(ShareCommand.MESSAGE_SHARE_PERSON_SUCCESS, shareInfo));
+    private void handleShareButtonAction() throws CommandException, ParseException {
+        commandExecutor.execute("share " + displayedIndex);
 
         shareButton.setText("Copied!");
 

--- a/src/main/java/socialite/ui/PersonCard.java
+++ b/src/main/java/socialite/ui/PersonCard.java
@@ -47,6 +47,8 @@ public class PersonCard extends UiPart<Region> {
      */
 
     public final Person person;
+    private final CommandExecutor commandExecutor;
+    private final int displayedIndex;
 
     @FXML
     private HBox cardPane;
@@ -103,11 +105,13 @@ public class PersonCard extends UiPart<Region> {
 
 
     /**
-     * Creates a {@code PersonCode} with the given {@code Person} and index to display.
+     * Creates a {@code PersonCode} with the given {@code CommandExecutor}, given {@code Person} and index to display.
      */
-    public PersonCard(Person person, int displayedIndex) {
+    public PersonCard(CommandExecutor commandExecutor, Person person, int displayedIndex) {
         super(FXML);
+        this.commandExecutor = commandExecutor;
         this.person = person;
+        this.displayedIndex = displayedIndex;
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);

--- a/src/main/java/socialite/ui/PersonListPanel.java
+++ b/src/main/java/socialite/ui/PersonListPanel.java
@@ -16,15 +16,17 @@ import socialite.model.person.Person;
 public class PersonListPanel extends UiPart<Region> {
     private static final String FXML = "PersonListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
+    private final CommandExecutor commandExecutor;
 
     @FXML
     private ListView<Person> personListView;
 
     /**
-     * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
+     * Creates a {@code PersonListPanel} with the given {@code CommandExecutor} and given {@code ObservableList}.
      */
-    public PersonListPanel(ObservableList<Person> personList) {
+    public PersonListPanel(CommandExecutor commandExecutor, ObservableList<Person> personList) {
         super(FXML);
+        this.commandExecutor = commandExecutor;
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
     }

--- a/src/main/java/socialite/ui/PersonListPanel.java
+++ b/src/main/java/socialite/ui/PersonListPanel.java
@@ -43,7 +43,7 @@ public class PersonListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new PersonCard(person, getIndex() + 1).getRoot());
+                setGraphic(new PersonCard(commandExecutor, person, getIndex() + 1).getRoot());
             }
         }
     }

--- a/src/test/java/socialite/ui/PersonCardTest.java
+++ b/src/test/java/socialite/ui/PersonCardTest.java
@@ -14,10 +14,10 @@ public class PersonCardTest extends GuiUnitTest {
     @Test
     public void equals() {
         Person person = new PersonBuilder().build();
-        PersonCard personCard = new PersonCard(person, 0);
+        PersonCard personCard = new PersonCard(null, person, 0);
 
         // same person, same index -> returns true
-        PersonCard copy = new PersonCard(person, 0);
+        PersonCard copy = new PersonCard(null, person, 0);
         assertTrue(personCard.equals(copy));
 
         // same object -> returns true
@@ -31,10 +31,10 @@ public class PersonCardTest extends GuiUnitTest {
 
         // different person, same index -> returns false
         Person differentPerson = new PersonBuilder().withName("differentName").build();
-        assertFalse(personCard.equals(new PersonCard(differentPerson, 0)));
+        assertFalse(personCard.equals(new PersonCard(null, differentPerson, 0)));
 
         // same person, different index -> returns false
-        assertFalse(personCard.equals(new PersonCard(person, 1)));
+        assertFalse(personCard.equals(new PersonCard(null, person, 1)));
     }
 
 


### PR DESCRIPTION
This PR extracts `CommandExecutor` interface into its own file, and passes the `MainWindow::executeCommand` method which fits the interface down to individual UI components `PersonListPanel` and then `PersonCard`. This allows the custom UI methods to use the same machinery for executing commands as `CommandBox` (with the exception of not adding the command to storage, since that is only done in `CommandBox`). This removes a source of duplication of code, and avoids a direct dependency on `MainWindow`.

TODO: update the DG if this will be merged.