### PR TITLE
MainApp: bump SociaLite version number to v1.4.0

### DIFF
--- a/src/main/java/socialite/MainApp.java
+++ b/src/main/java/socialite/MainApp.java
@@ -42,7 +42,7 @@ import socialite.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(1, 3, 2, false);
+    public static final Version VERSION = new Version(1, 4, 0, false);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 

--- a/src/main/java/socialite/MainApp.java
+++ b/src/main/java/socialite/MainApp.java
@@ -42,7 +42,7 @@ import socialite.ui.UiManager;
  */
 public class MainApp extends Application {
 
-    public static final Version VERSION = new Version(0, 2, 0, true);
+    public static final Version VERSION = new Version(1, 3, 2, false);
 
     private static final Logger logger = LogsCenter.getLogger(MainApp.class);
 


### PR DESCRIPTION
We forgot to do this for the past releases, and we should also do this before the v1.4 release as well.