### PR TITLE
Overhaul `edit` feature in UG

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -233,14 +233,17 @@ This command allows you to edit the information stored with a contact using your
 </div>
 
 <div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
+
 * Before you specify information for any field that you wish to modify, you should prepend your input with its corresponding flag (e.g. `n/` `p/` etc.) according to the format above.
 * You should check your input before you hit ENTER as SociaLite will overwrite the contact's existing information for any valid field that you furnish.
 * When you modify `TAG`s or `DATE`s, the existing `TAG`s or `DATE`s of the person will be removed i.e. adding of `TAG`s or `DATE`s is not cumulative.
 * Your input should conform with the character limit for the following fields:
+
     | Field    | Character Limit |
     | `TAG`    | 50              |
     | `DATE`   | 50              |
     | `REMARK` | 150             |
+
 </div>
 
 <div markdown="block" class="alert alert-success">
@@ -346,14 +349,14 @@ This command allows you to delete selected fields that are associated with a spe
 <div markdown="block" class="alert alert-success">
 **:heavy_check_mark: Example:** `edit 2 t/` 
 
-Deletes all tags associated with the 2nd person on the displayed person list.
+When you enter the above command, all tags associated with the 2nd person on the displayed person list are deleted.
 ![07_delete_tags](images/UG/07_delete_tags.png)
 </div>
 
 <div markdown="block" class="alert alert-success">
 **:heavy_check_mark: Example:** `edit 4 date/ fb/` 
 
-Deletes all dates and the Facebook handle associated with the 4th person on the displayed person list.
+When you enter the above command, all dates and the Facebook handle associated with the 4th person on the displayed person list are deleted.
 </div>
 
 <br>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -232,7 +232,7 @@ This command allows you to edit the information stored with a contact using your
 * Furthermore, upcoming dates (within 7 days) will be highlighted in the user interface.
 </div>
 
-<div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
+<div markdown="block" class="alert alert-warning">:exclamation: **Caution:**
 
 * Before you specify information for any field that you wish to modify, you should prepend your input with its corresponding flag (e.g. `n/` `p/` etc.) according to the format above.
 * You should check your input before you hit ENTER as SociaLite will overwrite the contact's existing information for any valid field that you furnish.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -128,11 +128,8 @@ Simply click on any command below to learn more about it!
 | [`list`](#list) | List all contacts |
 | [`CLICK`](#click) | Access a contact's social media page |
 | [`↑`/`↓`](#scroll) | Track history of commands |
-| [`edit INDEX ...`](#edit) | Edit a contact |
-| [`edit INDEX [t/TAG]`](#edit_tag) | Create / Edit tags for existing contacts |
-| [`edit INDEX t/`](#delete_tag) | Delete all tags from a contact |
-| [`edit INDEX [p/PLATFORM]`](#edit_platform) | Modify social media handles for a contact |
-| [`edit INDEX [date/NAME:YYYY-MM-DD[:monthly|:yearly]]…​`](#edit_dates) | Modify dates for a contact |
+| [`edit INDEX [k/KEYWORDS]...`](#edit) | Edit a contact |
+| [`edit INDEX [k/]...`](#delete_fields) | Delete optional fields from a contact |
 | [`delete INDEX`](#delete) | Delete a contact |
 | [`clear`](#clear) | Delete all contacts |
 | [`find NAME`](#find) | Find a contact by name |
@@ -218,81 +215,132 @@ Scroll through your history of commands using the `↑` or `↓` arrow keys.
 
 <br>
 
-### Edit a person : `edit INDEX ...` <a name="edit"></a>
+### Edit a person : `edit INDEX [k/KEYWORDS]...` <a name="edit"></a>
 
-Edits an existing contact on SociaLite.
+This command allows you to edit the information stored with a contact using your specified input.
 
 <div markdown="block" class="alert alert-primary">
 **:mag_right: Format:**
-`edit INDEX [n/NAME] [p/PHONE] [r/REMARK] [t/TAG]…​ [date/NAME:YYYY-MM-DD[:monthly|:yearly]]…​ [fb/FACEBOOK] [ig/INSTAGRAM] [tele/TELEGRAM] [tiktok/TIKTOK] [twitter/TWITTER]`
-* Edits the person at the specified `INDEX`. The index refers to the index number shown on the displayed person list. 
+`edit INDEX [k/KEYWORDS]...`
+* Information of the contact at your specified `INDEX` will be modified. 
+* The index refers to the index number shown on the displayed person list. 
 * The index **must be a positive integer** 1, 2, 3, …​
-* At least one of the optional fields must be provided.
-* Users can opt to change any fields associated with a contact as long as they prepend the argument with the corresponding flags according to the format above.
-* Existing values will be updated to the input values.
-* When editing tags, the existing tags of the person will be removed i.e adding of tags is not cumulative.
-* You can remove all the person’s tags by typing `t/` without
-    specifying any tag after it.
-* When editing dates, all existing dates of the person will be removed i.e adding of dates is not cumulative.
-* You can remove all the person’s dates by typing `date/` without
-  specifying any date after it.
+* You can provide the following fields (i.e. `[k/KEYWORDS]`) in any order when editing a contact's information: `[n/NAME] [p/PHONE] [r/REMARK] [t/TAG]…​ [date/NAME:YYYY-MM-DD[:monthly|:yearly]]…​ [fb/FACEBOOK] [ig/INSTAGRAM] [tele/TELEGRAM] [tiktok/TIKTOK] [twitter/TWITTER]` 
+* You should provide at least one field from the above list for this command to run successfully.
+* In addition, you can add a name for each `DATE` (e.g. Birthday, Meet-Up, Anniversary).
+* If your dates represent events that recur monthly or yearly, you can add the keyword `:monthly` or `:yearly` behind the date which has to be specified in `YYYY-MM-DD` format.
+* Furthermore, upcoming dates (within 7 days) will be highlighted in the user interface.
+</div>
+
+<div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
+* Before you specify information for any field that you wish to modify, you should prepend your input with its corresponding flag (e.g. `n/` `p/` etc.) according to the format above.
+* You should check your input before you hit ENTER as SociaLite will overwrite the contact's existing information for any valid field that you furnish.
+* When you modify `TAG`s or `DATE`s, the existing `TAG`s or `DATE`s of the person will be removed i.e. adding of `TAG`s or `DATE`s is not cumulative.
+* Your input should conform with the character limit for the following fields:
+    | Field    | Character Limit |
+    | `TAG`    | 50              |
+    | `DATE`   | 50              |
+    | `REMARK` | 150             |
 </div>
 
 <div markdown="block" class="alert alert-success">
-**:heavy_check_mark: Example:** `edit 1 p/91234567 fb/Yalex19` 
+**:heavy_check_mark: Example:** Edit `NAME`
 
-Edits the phone number and Facebook handle of the 1st person to be `91234567` and `Yalex19` respectively.
+`edit 5 n/Eric Wong` 
+
+When you enter the above command, the name of the 5th person is changed to `Eric Wong`.
+</div>
+
+<div markdown="block" class="alert alert-success">
+**:heavy_check_mark: Example:** Edit `PHONE`
+
+`edit 6 p/91082857`
+
+When you enter the above command, the phone number of the 6th person is changed to `91082857`.
+</div>
+
+<div markdown="block" class="alert alert-success">
+**:heavy_check_mark: Example:** Edit one `TAG`
+
+`edit 1 t/buddy`
+
+When you enter the above command, a tag called `buddy` is created for the first person on the displayed person list.
+![06_edit_tag](images/UG/06_edit_tag.png)
+</div>
+
+<div markdown="block" class="alert alert-success">
+**:heavy_check_mark: Example:** Edit two `TAG`s
+
+`edit 2 t/friend t/neighbour`
+
+When you enter the above command, the tags called `friend` and `neighbour` are added for the second person on the displayed person list.
+</div>
+
+<div markdown="block" class="alert alert-success">
+**:heavy_check_mark: Example:** Edit `FACEBOOK` handle
+
+`edit 1 fb/al3x.ye0h` 
+
+When you enter the above command, you change the Facebook handle of the first person on the displayed person list to `al3x.ye0h`. Other handles will not be affected by this change.
+</div>
+
+<div markdown="block" class="alert alert-success">
+**:heavy_check_mark: Example:** Add `TWITTER` handle
+
+`edit 1 twitter/xelayeoh` 
+
+When you enter the above command, you add the Twitter handle called `xelayeoh` to the first person on the displayed person list. Other handles will not be affected by this addition.
+![08_edit_handles](images/UG/08_edit_handles.png)
+</div>
+
+<div markdown="block" class="alert alert-success">
+**:heavy_check_mark: Example:** Add a non-recurring `DATE`
+
+`list` followed by `edit 1 date/Meeting:2021-09-14` 
+
+This allows you to add the one-off event, “Meeting”, which falls on 14 Sep 2021, to Alex Yeoh’s listing.
+![09_edit_dates](images/UG/09_edit_dates.png)
+</div>
+
+<div markdown="block" class="alert alert-success">
+**:heavy_check_mark: Example:** Add a `DATE` that recurs yearly
+
+`find Bernice` followed by `edit 1 date/Birthday:1999-09-09:yearly` 
+
+This allows you to add the event “Birthday” which falls on 9 Sep every year to Bernice Yu’s listing.
+</div>
+
+<div markdown="block" class="alert alert-success">
+**:heavy_check_mark: Example:** Edit multiple fields: `n/NAME` and `fb/FACEBOOK`
+
+`edit 1 p/91234567 fb/Yalex19` 
+
+This command allows you to change the phone number and Facebook handle of the 1st person to `91234567` and `Yalex19` respectively.
 ![05_edit](images/UG/05_edit.png)
 </div>
 
 <div markdown="block" class="alert alert-success">
-**:heavy_check_mark: Example:** `edit 4 n/Betsy Crower t/`
+**:heavy_check_mark: Example:** Edit multiple fields: `p/94850285` and `t/TAG`
 
-Edits the name of the 4th person to be `Betsy Crower` and clears all existing tags.
+`edit 4 p/94850285 t/Boss`
+
+This command allows you to change the phone number of the 4th person to `94850285` and adds the tag `Boss`.
 </div>
 
 <br>
 
-### Create / Edit tags for existing contacts: `edit INDEX [t/TAG]...` <a name="edit_tag"></a>
+### Delete optional fields associated with contacts: `edit INDEX [k/]...` <a name="delete_fields"></a>
 
-Modifies tags that are associated with existing contacts stored on SociaLite.
-
-<div markdown="block" class="alert alert-primary">
-**:mag_right: Format:**
-`edit INDEX [t/TAG]...`
-* Adds new tags to persons who did not have tags associated with them when they were first added to SociaLite.
-* Deletes all existing tags for the person at the specified `INDEX` and replaces them with tags specified in `[t/TAG]...`
-* Each tag can only be up to 50 characters long.
-* The index refers to the index number shown on the displayed person list.
-* The index **must be a positive integer** 1, 2, 3, …​
-</div>
-
-<div markdown="block" class="alert alert-success">
-**:heavy_check_mark: Example:** `edit 1 t/buddy`
-
-Creates a tag called `buddy` for the first person on the displayed person list.
-![06_edit_tag](images/UG/06_edit_tag.png)
-</div>
-
-
-<div markdown="block" class="alert alert-success">
-**:heavy_check_mark: Example:** `edit 2 t/friend t/neighbour`
-
-Creates tags called `friend` and `neighbour` for the second person on the displayed person list.
-</div>
-
-<br>
-
-### Delete tags associated with contacts: `edit INDEX t/` <a name="delete_tag"></a>
-
-Deletes all tags that are associated with a specified contact on SociaLite.
+This command allows you to delete selected fields that are associated with a specified contact on SociaLite.
 
 <div markdown="block" class="alert alert-primary">
 **:mag_right: Format:**
-`edit INDEX t/`
-* Deletes all categories tagged to the person at the specified `INDEX`.
-* The index refers to the index number shown on the displayed person list.
+`edit INDEX [k/]...`
+* Information of the contact at your specified `INDEX` will be deleted. 
+* The index refers to the index number shown on the displayed person list. 
 * The index **must be a positive integer** 1, 2, 3, …​
+* You can provide the following flags (i.e. `[k/]...`) in any order when deleting a contact's information: `[t/] [date/] [fb/] [ig/] [tele/] [tiktok/] [twitter/]` 
+* You should provide at least one field from the above list for this command to run successfully.
 </div>
 
 <div markdown="block" class="alert alert-success">
@@ -302,69 +350,10 @@ Deletes all tags associated with the 2nd person on the displayed person list.
 ![07_delete_tags](images/UG/07_delete_tags.png)
 </div>
 
-<br>
-
-### Add / Edit social media handles for existing contacts: `edit INDEX [fb/FACEBOOK] [ig/INSTAGRAM] [tele/TELEGRAM] [tiktok/TIKTOK] [twitter/TWITTER]` <a name="edit_platform"></a>
-
-Modifies social media handles that are associated with existing contacts on SociaLite.
-
-<div markdown="block" class="alert alert-primary">
-**:mag_right: Format:**
-`edit INDEX [fb/FACEBOOK] [ig/INSTAGRAM] [tele/TELEGRAM] [tiktok/TIKTOK] [twitter/TWITTER]`
-* Adds a new handle for contacts who did not have that specific handle pegged with them when they were first added to SociaLite.
-* Replaces the handle for the person at the specified `INDEX` according to the flag and input provided.
-* The index refers to the index number shown on the displayed person list.
-* The index **must be a positive integer** 1, 2, 3, …​
-* The flag refers to any of the following: `fb/` `ig/` `tele/` `tiktok/` `twitter/`
-* User input after the given flag represents the new social media handle associated with the contact.
-* Only social media handles specified as input will be altered. Other social media handles remain unchanged.
-</div>
-
 <div markdown="block" class="alert alert-success">
-**:heavy_check_mark: Example:** `edit 1 fb/al3x.ye0h` 
+**:heavy_check_mark: Example:** `edit 4 date/ fb/` 
 
-Changes the Facebook handle of the first person on the displayed person list to `al3x.ye0h`.
-</div>
-
-<div markdown="block" class="alert alert-success">
-**:heavy_check_mark: Example:** `edit 1 twitter/xelayeoh` 
-
-Adds the Twitter handle called `xelayeoh` to the first person on the displayed person list. The Facebook handle that was previously modified is unaffected.
-![08_edit_handles](images/UG/08_edit_handles.png)
-</div>
-
-<br>
-
-### Add / Edit dates of occasions associated with contacts: `edit INDEX [date/NAME:YYYY-MM-DD[:monthly|:yearly]]…​` <a name="edit_dates"></a>
-
-Adds / Edits dates of occasions (birthdays, appointments) associated with a contact.
-
-<div markdown="block" class="alert alert-primary">
-**:mag_right: Format:**
-`edit INDEX [date/NAME:YYYY-MM-DD[:monthly|:yearly]]…​`
-* Adds a date for the contact at the specified `INDEX`.
-* The index refers to the index number shown on the displayed person list.
-* The index **must be a positive integer** 1, 2, 3, …​
-* Dates can have a name to associate them with a specific event (eg. Birthday, Meetup, Anniversary).
-* The name associated with the event can only be up to 50 characters long.
-* Date must be presented in `YYYY-MM-DD` format.
-* Dates can be recurring, either monthly or yearly, by adding `:monthly` or `:yearly` behind the date.
-* Each call of `edit INDEX [date/NAME:YYYY-MM-DD[:monthly|:yearly]]…​` will replace all previous dates.
-* Using the command `edit INDEX date/` will remove all dates from the user.
-* Upcoming dates (within 7 days) will be highlighted in the user interface.
-</div>
-
-<div markdown="block" class="alert alert-success">
-**:heavy_check_mark: Example:** `list` followed by `edit 1 date/Meeting:2021-09-14` 
-
-Adds the event “Meeting” which falls on 14 Sep 2021, to Alex Yeoh’s listing.
-![09_edit_dates](images/UG/09_edit_dates.png)
-</div>
-
-<div markdown="block" class="alert alert-success">
-**:heavy_check_mark: Example:** `find Bernice` followed by `edit 1 date/Birthday:1999-09-09:yearly` 
-
-Adds the event “Birthday” which falls on 9 Sep every year to Bernice Yu’s listing.
+Deletes all dates and the Facebook handle associated with the 4th person on the displayed person list.
 </div>
 
 <br>

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -225,7 +225,7 @@ This command allows you to edit the information stored with a contact using your
 * Information of the contact at your specified `INDEX` will be modified. 
 * The index refers to the index number shown on the displayed person list. 
 * The index **must be a positive integer** 1, 2, 3, …​
-* You can provide the following fields (i.e. `[k/KEYWORDS]`) in any order when editing a contact's information: `[n/NAME] [p/PHONE] [r/REMARK] [t/TAG]…​ [date/NAME:YYYY-MM-DD[:monthly|:yearly]]…​ [fb/FACEBOOK] [ig/INSTAGRAM] [tele/TELEGRAM] [tiktok/TIKTOK] [twitter/TWITTER]` 
+* You can provide the following fields (i.e. `[k/KEYWORDS]`) in any order when editing a contact's information: `[n/NAME] [p/PHONE] [r/REMARK] [t/TAG]…​ [date/NAME:YYYY-MM-DD[:monthly|:yearly]]…​ [fb/FACEBOOK] [ig/INSTAGRAM] [tele/TELEGRAM] [tiktok/TIKTOK] [twitter/TWITTER]`. 
 * You should provide at least one field from the above list for this command to run successfully.
 * In addition, you can add a name for each `DATE` (e.g. Birthday, Meet-Up, Anniversary).
 * If your dates represent events that recur monthly or yearly, you can add the keyword `:monthly` or `:yearly` behind the date which has to be specified in `YYYY-MM-DD` format.
@@ -247,7 +247,7 @@ This command allows you to edit the information stored with a contact using your
 </div>
 
 <div markdown="block" class="alert alert-success">
-**:heavy_check_mark: Example:** Edit `NAME`
+**:heavy_check_mark: Example:** Edit contact's name
 
 `edit 5 n/Eric Wong` 
 
@@ -255,7 +255,7 @@ When you enter the above command, the name of the 5th person is changed to `Eric
 </div>
 
 <div markdown="block" class="alert alert-success">
-**:heavy_check_mark: Example:** Edit `PHONE`
+**:heavy_check_mark: Example:** Edit phone number
 
 `edit 6 p/91082857`
 
@@ -263,7 +263,7 @@ When you enter the above command, the phone number of the 6th person is changed 
 </div>
 
 <div markdown="block" class="alert alert-success">
-**:heavy_check_mark: Example:** Edit one `TAG`
+**:heavy_check_mark: Example:** Edit one tag
 
 `edit 1 t/buddy`
 
@@ -272,7 +272,7 @@ When you enter the above command, a tag called `buddy` is created for the first 
 </div>
 
 <div markdown="block" class="alert alert-success">
-**:heavy_check_mark: Example:** Edit two `TAG`s
+**:heavy_check_mark: Example:** Edit two tags
 
 `edit 2 t/friend t/neighbour`
 
@@ -280,7 +280,7 @@ When you enter the above command, the tags called `friend` and `neighbour` are a
 </div>
 
 <div markdown="block" class="alert alert-success">
-**:heavy_check_mark: Example:** Edit `FACEBOOK` handle
+**:heavy_check_mark: Example:** Edit Facebook handle
 
 `edit 1 fb/al3x.ye0h` 
 
@@ -288,7 +288,7 @@ When you enter the above command, you change the Facebook handle of the first pe
 </div>
 
 <div markdown="block" class="alert alert-success">
-**:heavy_check_mark: Example:** Add `TWITTER` handle
+**:heavy_check_mark: Example:** Add Twitter handle
 
 `edit 1 twitter/xelayeoh` 
 
@@ -323,7 +323,7 @@ This command allows you to change the phone number and Facebook handle of the 1s
 </div>
 
 <div markdown="block" class="alert alert-success">
-**:heavy_check_mark: Example:** Edit multiple fields: `p/94850285` and `t/TAG`
+**:heavy_check_mark: Example:** Edit multiple fields: `p/PHONE` and `t/TAG`
 
 `edit 4 p/94850285 t/Boss`
 


### PR DESCRIPTION
Consolidated `edit`-related features under [`edit INDEX [k/KEYWORDS]...`](https://stanley-1.github.io/tp/UserGuide.html#edit) and [`edit INDEX [k/]...`](https://stanley-1.github.io/tp/UserGuide.html#delete_fields) respectively.

Click on the links to access the UG and evaluate the changes on my repo.